### PR TITLE
Added prefix to GET /api/countries endpoint

### DIFF
--- a/express-app/src/controllers/countries.ts
+++ b/express-app/src/controllers/countries.ts
@@ -7,7 +7,8 @@ const countryData = new CountryData(jsonDataHandler)
 
 export const getCountries = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const countries = await countryData.getCountries()
+    const prefix = !req.query.prefix ? '' : req.query.prefix.toString()
+    const countries = await countryData.getCountries(prefix)
     
     res.json(countries)
   } catch (error) {

--- a/express-app/src/exceptions/argument-exception.ts
+++ b/express-app/src/exceptions/argument-exception.ts
@@ -1,0 +1,7 @@
+import { ErrorCode, HttpException } from "./http-exception";
+
+export class ArgumentException extends HttpException {
+  constructor(message: string, errorCode: ErrorCode, statusCode: number, errors: any = 'Argument error'){
+    super(message, errorCode, statusCode, errors)
+  }
+}

--- a/express-app/src/exceptions/http-exception.ts
+++ b/express-app/src/exceptions/http-exception.ts
@@ -14,5 +14,6 @@ export class HttpException extends Error {
 }
 
 export enum ErrorCode {
-  INTERNAL_ERROR = 1001
+  INTERNAL_ERROR = 1001,
+  ARGUMENT_ERROR = 2001
 }

--- a/express-app/src/interfaces/countries-retrievable.ts
+++ b/express-app/src/interfaces/countries-retrievable.ts
@@ -1,5 +1,5 @@
 interface CountriesRetrievable{
-  getCountries(): Promise<string[]>;
+  getCountries(prefix: string): Promise<string[]>;
 }
 
 export default CountriesRetrievable;

--- a/express-app/src/interfaces/data-handleable.ts
+++ b/express-app/src/interfaces/data-handleable.ts
@@ -1,5 +1,5 @@
 interface DataHandleable {
-  getCountries(): Promise<string[]>;
+  getCountries(prefix: string): Promise<string[]>;
 }
 
 export default DataHandleable

--- a/express-app/src/lib/country-data.ts
+++ b/express-app/src/lib/country-data.ts
@@ -9,8 +9,8 @@ class CountryData implements CountriesRetrievable {
     this.dataHandler = dataHandler
   }
 
-  async getCountries(): Promise<string[]> {
-    const countries = await this.dataHandler.getCountries();
+  async getCountries(prefix: string): Promise<string[]> {
+    const countries = await this.dataHandler.getCountries(prefix);
     // Removing duplicates
     let uniqueCountries = [...new Set(countries)];
     // Sorted

--- a/express-app/src/lib/json-data-handler.ts
+++ b/express-app/src/lib/json-data-handler.ts
@@ -33,14 +33,24 @@ class JsonDataHandler implements DataHandleable{
     }
   }
 
-  async getCountries(): Promise<string[]> {
+  async getCountries(prefix: string): Promise<string[]> {
     await this.loadDataFromFile()
 
-    const countries = this.countryMetrics!.map((dataObj: MetricData) => {
-      return dataObj.country;
-    })
+    let countryMetricsArr = this.countryMetrics;
 
-    return countries
+    if(prefix !== ''){
+      const prefixLowercase = prefix.toLowerCase();
+      countryMetricsArr = this.countryMetrics?.filter((dataObj) => {
+        let words = dataObj.country.split(' ');
+        let matchingWords = words.filter((word) => {
+          return word.toLowerCase().startsWith(prefixLowercase);
+        });
+        
+        return matchingWords.length > 0;
+      })!
+    }
+
+    return countryMetricsArr?.map((dataObj) => dataObj.country )!
   }
 }
 


### PR DESCRIPTION
- Alter your endpoint which lists countries to accept a parameter called "prefix". Only country names which contain the value of the prefix parameter at the start of a word should be returned, e.g. "Aus" should return both "Austria" and "Australia"; "Tanz" would return "United Republic of Tanzania".